### PR TITLE
Refresh GitHub workflows and fix README formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -22,13 +29,14 @@ jobs:
     env:
       DATABASE_URL: postgres://warcon:warcon@127.0.0.1:5432/warcon
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - run: bun install --frozen-lockfile
       - run: bun run lint
       - run: bun run check
+      - run: bun test
       - run: bun run build
       - name: Smoke test the production build
         env:
@@ -37,22 +45,27 @@ jobs:
           HOST: 127.0.0.1
           POLL_SECONDS: 5
         run: |
-          export BETTER_AUTH_SECRET=$(openssl rand -base64 32)
-          export ENCRYPTION_KEY=$(openssl rand -base64 32)
+          BETTER_AUTH_SECRET=$(openssl rand -base64 32); export BETTER_AUTH_SECRET
+          ENCRYPTION_KEY=$(openssl rand -base64 32); export ENCRYPTION_KEY
           bun ./build/index.js > server.log 2>&1 &
-          for i in $(seq 1 60); do sleep 1; curl -sf http://127.0.0.1:5199/api/health >/dev/null && break; done
+          up=0
+          for _ in $(seq 1 60); do
+            if curl -sf "$ORIGIN/api/health" >/dev/null; then up=1; break; fi
+            sleep 1
+          done
+          if [ "$up" != 1 ]; then echo "::error::server did not become healthy within 60s"; exit 1; fi
           bash scripts/smoke.sh | tee smoke.out
           grep -q 'failed=0' smoke.out
       - name: Server log
-        if: failure()
+        if: failure() && hashFiles('server.log') != ''
         run: cat server.log
 
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,23 +12,24 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@v7
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
-      - uses: docker/build-push-action@v6
+            # Pre-release tags (v1.2.0-rc1) must not move :latest
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+      - uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ anywhere that can reach `Port` (default 7776) on each game host. Enable the list
 
   For a self-signed certificate set `GAME_TLS_INSECURE=true`. This applies to every `https` server,
   not just the one that needs it.
+
 - **Same host as the game server.** Keep `BindAddress=127.0.0.1`. From Compose, uncomment the
   `extra_hosts` line in `docker-compose.yml` and use host `host.docker.internal`, or run the
   container with `network_mode: host`.


### PR DESCRIPTION
- Fix the Prettier failure on README.md that has broken CI on main
- Run bun test in CI; it was never wired in
- Fail the smoke step clearly if the server never becomes healthy
- Only print server.log when it exists so the log step stops failing
- Add read-only permissions and cancel superseded runs
- Bump checkout to v7 and the docker actions to their Node 24 majors
- Don't move the :latest image tag on pre-release tags